### PR TITLE
Corrects some JSDoc parameter types in thumbor.js

### DIFF
--- a/src/thumbor.js
+++ b/src/thumbor.js
@@ -1,7 +1,7 @@
 module.exports = function createThumbor (createHmac) {
   /**
-   * @param {[type]} securityKey
-   * @param {[type]} thumborServerUrl
+   * @param {String} securityKey
+   * @param {String} thumborServerUrl
    */
   function Thumbor(securityKey, thumborServerUrl) {
     'use strict';
@@ -138,8 +138,8 @@ module.exports = function createThumbor (createHmac) {
      *
      * Use a value of 'orig' to use an original image dimension. E.g. for a 640
      * x 480 image, `.resize(320, 'orig')` yields a 320 x 480 thumbnail.
-     * @param  {String} width
-     * @param  {String} height
+     * @param  {String|Number} width
+     * @param  {String|Number} height
      */
     resize: function(width, height) {
       this.width = width;


### PR DESCRIPTION
We've been seeing the following, minor TypeScript errors in our project, so I thought I'd submit a quick PR:

```javascript
const thumborInstance = new Thumbor(securityKey, thumborServerUrl);
// "Argument of type 'string' is not assignable to parameter of type '[any]'."
```

```javascript
thumborInstance.resize(width, height)
// Argument of type 'number' is not assignable to parameter of type 'string'.
```

VSCode picks up the JSDoc annotation for its TypeScript compiler: https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html. The above errors aren't breaking anything, so this PR isn't very important.